### PR TITLE
chore(dirPacker): add dirPacker to options

### DIFF
--- a/index.js
+++ b/index.js
@@ -370,7 +370,10 @@ class Installer {
         pkg, stage, pkgPath, LifecycleOpts(this.opts).concat({
           // TODO: can be removed once npm-lifecycle is updated to modern
           //       config practices.
-          config: Object.assign({}, this.opts, { log: null }),
+          config: Object.assign({}, this.opts, {
+            log: null,
+            dirPacker: null
+          }),
           dir: this.prefix
         }))
       ).tap(() => { this.timings.scripts += Date.now() - start })

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -12,7 +12,8 @@ let workerFarm
 const ENABLE_WORKERS = false
 
 const ExtractOpts = figgyPudding({
-  log: {}
+  log: {},
+  dirPacker: {}
 })
 
 module.exports = {

--- a/test/specs/lib/extract.js
+++ b/test/specs/lib/extract.js
@@ -10,6 +10,20 @@ const extract = requireInject('../../../lib/extract.js', {
   }
 })
 
+test('extract.child() ensures dirPacker is defined', t => {
+  const name = 'name'
+  const child = { version: '0.0.0', integrity: 'integrity', resolved: 'resolved' }
+  const childPath = './path'
+
+  const opts = { log: { level: 'level' }, dirPacker: {} }
+  const a = extract.child(name, child, childPath, opts)
+
+  a.then(b => {
+    t.ok('dirPacker' in b[2], 'dirPacker is defined')
+    t.end()
+  })
+})
+
 test('extract.child() only overwrites dirPacker when opts.dirPacker is defined', t => {
   const name = 'name'
   const child = { version: '0.0.0', integrity: 'integrity', resolved: 'resolved' }


### PR DESCRIPTION
## :pencil2: Changes
This PR adds a test to make sure dirPacker is correctly defined on extract and ensures no functions are passed to lifecycle options.

## :link: References
See: https://github.com/npm/cli/pull/252
Fixes: https://npm.community/t/npm-6-11-2-npm-ci-not-copying-prepared-files/9718

## :mag: Testing
_Automated testing_
- Checks if extract.child() ensures dirPacker is defined

✅ This change has unit test coverage