### PR TITLE
Respect no-optional argument for dev dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -245,7 +245,7 @@ class Installer {
     )
     const includeProd = !/^dev(elopment)?$/.test(this.opts.only)
     const includeOptional = includeProd && this.opts.optional
-    return (dep.dev && includeDev) ||
+    return (dep.dev && includeDev && (!dep.optional || (dep.optional && includeOptional))) ||
       (dep.optional && includeOptional) ||
       (!dep.dev && !dep.optional && includeProd)
   }

--- a/test/specs/index.js
+++ b/test/specs/index.js
@@ -608,6 +608,45 @@ test('don\'t install optional dependencies with no-optional argument', t => {
   })
 })
 
+test('don\'t install optional dev dependencies with no-optional argument', t => {
+  const fixture = new Tacks(Dir({
+    'package.json': File({
+      name: pkgName,
+      version: pkgVersion,
+      dependencies: { a: '^1' },
+      devDependencies: { b: '^1', c: '^1' },
+      optionalDependencies: { c: '^1' }
+    }),
+    'package-lock.json': File({
+      lockfileVersion: 1,
+      dependencies: {
+        a: { version: '1.0.0' },
+        b: { version: '1.0.0', dev: true },
+        c: { version: '1.0.0', dev: true, optional: true }
+      }
+    })
+  }))
+  fixture.create(prefix)
+
+  extract = (name, child, childPath, opts) => {
+    const files = new Tacks(Dir({
+      'package.json': File({
+        name,
+        version: '1.0.0'
+      })
+    }))
+    files.create(childPath)
+  }
+
+  return run({ dev: true, optional: false }).then(details => {
+    t.ok(fs.statSync(path.join(prefix, 'node_modules', 'a')), 'dep a is there')
+    t.ok(fs.statSync(path.join(prefix, 'node_modules', 'b')), 'dev dep b is there')
+    t.throws(() => {
+      fs.statSync(path.join(prefix, 'node_modules', 'c'))
+    }, 'optional & dev dep c is not there')
+  })
+})
+
 test('runs lifecycle hooks of packages with env variables', t => {
   const originalConsoleLog = console.log
   console.log = () => {}


### PR DESCRIPTION
There's no issue filed for this on this repo, but we ran into this in one of our pipelines, which runs without problems now with this patch, so I decided to just open a PR here.

The main issue for us was the `fsevents` package (not a direct dependency), which looks somewhat like this in `package-lock.json`:

```json
"fsevents": {
    "version": "x.y.z",
    "dev": true,
    "optional": true
}
```

That means that the package gets installed as soon as dev dependencies get installed, even if `--no-optional` is passed, which is not really desirable as far as I can see. 

This PR adds an additional check when installing dev dependencies so that they won't get installed if they're also optional and optional dependencies should be skipped. 

I added a test case (which fails without the fix and succeeds with the fix as expected), but I'm not 100% on the `package.json` fixture since for us the problematic packages were all not direct dependencies.

Could also be related to https://github.com/npm/cli/issues/475.

