### PR TITLE
fix: fully delete node modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,7 +137,8 @@ class Installer {
         )
         return BB.join(
           this.checkLock(),
-          stat && rimraf(path.join(this.prefix, 'node_modules/*'))
+          stat && rimraf(path.join(this.prefix, 'node_modules/*')),
+          stat && rimraf(path.join(this.prefix, 'node_modules/.*'))
         )
       }).then(() => {
       // This needs to happen -after- we've done checkLock()

--- a/index.js
+++ b/index.js
@@ -138,7 +138,7 @@ class Installer {
         return BB.join(
           this.checkLock(),
           stat && rimraf(path.join(this.prefix, 'node_modules/*')),
-          stat && rimraf(path.join(this.prefix, 'node_modules/.*'))
+          stat && rimraf(path.join(this.prefix, 'node_modules/.*[0-9a-zA-Z]'))
         )
       }).then(() => {
       // This needs to happen -after- we've done checkLock()

--- a/test/specs/index.js
+++ b/test/specs/index.js
@@ -176,6 +176,12 @@ test('deletes node_modules/ contents, without deleting node_modules/ itself', t 
           name: 'stale-dependency',
           version: '1.0.0'
         })
+      }),
+      '.cache': Dir({
+        'package.json': File({
+          name: '.cache',
+          version: '1.0.0'
+        })
       })
     }),
     'package.json': File({
@@ -200,7 +206,11 @@ test('deletes node_modules/ contents, without deleting node_modules/ itself', t 
   return run().then(() => {
     t.ok(
       !fs.existsSync(path.join(nodeModulesDir, 'stale-dependency')),
-      'node_modules/ contents were deleted'
+      'node_modules/ contents were deleted - normal folders'
+    )
+    t.ok(
+      !fs.existsSync(path.join(nodeModulesDir, '.cache')),
+      'node_modules/ contents were deleted - dot folders'
     )
     watcher.close()
     t.ok(notNodeModulesDeleted, 'node_modules/ itself was not deleted')


### PR DESCRIPTION
At present when clearing down node_modules folders starting with a period are left.
Example: `.bin` and `.cache`

This is due to the globbing pattern used which cannot match files or folders starting with period.

This adds a second deletion to match these folders and a corresponding test.

Fixes: #7 