### PR TITLE
fix: resolve parent for non-registry dep on only mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -322,7 +322,7 @@ class Installer {
   updateFromField (dep, pkg) {
     const depPath = dep.path(this.prefix)
     const depPkgPath = path.join(depPath, 'package.json')
-    const parent = dep.requiredBy.values().next().value
+    const parent = this.findParent(dep)
     return readJson(parent.path(this.prefix), 'package.json')
       .then(ppkg =>
         (ppkg.dependencies && ppkg.dependencies[dep.name]) ||
@@ -333,6 +333,16 @@ class Installer {
       .then(from => { pkg._from = from.toString() })
       .then(() => writeFileAsync(depPkgPath, JSON.stringify(pkg, null, 2)))
       .then(() => pkg)
+  }
+
+  findParent (dep) {
+    for (const parent of dep.requiredBy.values()) {
+      if (this.checkDepEnv(parent)) {
+        return parent
+      }
+    }
+
+    return null
   }
 
   updateInstallScript (dep, pkg) {

--- a/test/specs/index.js
+++ b/test/specs/index.js
@@ -268,6 +268,76 @@ test('handles dependency list with only deep subdeps', t => {
   })
 })
 
+test('resolves prod parent dependency for non-registry dep, when only production', t => {
+  const fixture = new Tacks(Dir({
+    'package.json': File({
+      name: pkgName,
+      version: pkgVersion,
+      dependencies: {
+        a: '^1'
+      },
+      devDependencies: {
+        b: '^1'
+      }
+    }),
+    'package-lock.json': File({
+      dependencies: {
+        c: {
+          version: 'github:foo/c#aaaabbbb',
+          from: 'github:foo/c#v1.1.1'
+        },
+        b: {
+          version: '1.1.1',
+          dev: true,
+          requires: {
+            c: 'github:foo/c#aaaabbbb'
+          }
+        },
+        a: {
+          version: '1.1.1',
+          requires: {
+            c: '1.1.1'
+          }
+        }
+      },
+      lockfileVersion: 1
+    })
+  }))
+  fixture.create(prefix)
+
+  const aContents = 'var a = 1;'
+  const cContents = 'var c = 2;'
+
+  extract = (name, child, childPath, opts) => {
+    const files = new Tacks(Dir({
+      'package.json': File({
+        name: name,
+        version: child.version
+      }),
+      'index.js': File(name === 'a' ? aContents : cContents)
+    }))
+    files.create(childPath)
+  }
+
+  return run({ production: true, only: true }).then(details => {
+    t.equal(details.pkgCount, 2)
+    return BB.join(
+      fs.readFileAsync(
+        path.join(prefix, 'node_modules', 'a', 'index.js'),
+        'utf8'
+      ),
+      fs.readFileAsync(
+        path.join(prefix, 'node_modules', 'c', 'index.js'),
+        'utf8'
+      ),
+      (a, b) => {
+        t.equal(a, aContents, 'first-level dep extracted correctly')
+        t.equal(b, cContents, 'nested dep extracted correctly')
+      }
+    )
+  })
+})
+
 test('installs `directory` dependencies as symlinks', t => {
   const fixture = new Tacks(Dir({
     'package.json': File({


### PR DESCRIPTION
When a prod dependency `A` and a dev dependency `B` both depend on a dependency `C` that is not installed through a registry (eg. was installed through github), and we are running in production-only mode, the `updateJson` process fails because the parent dependency `package.json` file cannot be resolved.

We ran into this issue while moving from `yarn` to `npm`. Our project used a mix of registry and github installed dependencies. When attempting to run `npm ci --production`, the task failed with an `enoent ENOENT: no such file or directory` error when reaching the `updateJson` stage.

The PR includes a fix that picks the first parent that is a valid dependency for the mode we are running in. 

The test describes the case we ran into. 

We tested the fix successfully in our project.

closes: https://github.com/npm/libcipm/issues/23